### PR TITLE
feat: Add Exec method to Query interface for executing SQL commands

### DIFF
--- a/dbal/query/exec.go
+++ b/dbal/query/exec.go
@@ -1,0 +1,13 @@
+package query
+
+import "database/sql"
+
+// Exec execute the sql, return the result
+func (builder *Builder) Exec(sql string, bindings ...interface{}) (sql.Result, error) {
+	stmt, err := builder.DB().Prepare(sql)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+	return stmt.Exec(bindings...)
+}

--- a/dbal/query/exec_test.go
+++ b/dbal/query/exec_test.go
@@ -1,0 +1,32 @@
+package query
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExec(t *testing.T) {
+	NewTableForQueryTest()
+	qb := getTestBuilder()
+	rows := qb.From("table_test_query as t").
+		Where("email", "like", "%@yao.run").
+		OrderBy("id").
+		MustGet()
+
+	assert.Equal(t, 4, len(rows), "the return rows should have 4 items")
+	if len(rows) == 4 {
+		assert.Equal(t, "96.32", fmt.Sprintf("%.2f", rows[0].Get("score")), "the return value should be true")
+		assert.Equal(t, "64.56", fmt.Sprintf("%.2f", rows[1].Get("score")), "the return value should be true")
+		assert.Equal(t, "99.27", fmt.Sprintf("%.2f", rows[2].Get("score")), "the return value should be true")
+		assert.Equal(t, "48.12", fmt.Sprintf("%.2f", rows[3].Get("score")), "the return value should be true")
+	}
+
+	// Exec
+	res, err := qb.Exec("update table_test_query set score = 100 where email like ?", "%@yao.run")
+	assert.Nil(t, err, "the error should be nil")
+	affected, err := res.RowsAffected()
+	assert.Nil(t, err, "the error should be nil")
+	assert.Equal(t, int64(4), affected, "the rows affected should be 4")
+}

--- a/dbal/query/interfaces.go
+++ b/dbal/query/interfaces.go
@@ -1,6 +1,8 @@
 package query
 
 import (
+	"database/sql"
+
 	"github.com/jmoiron/sqlx"
 	"github.com/yaoapp/xun"
 )
@@ -174,6 +176,9 @@ type Query interface {
 	MustDelete() int64
 	Truncate() error
 	MustTruncate()
+
+	// defined in the exec.go file
+	Exec(sql string, bindings ...interface{}) (sql.Result, error)
 
 	// defined in the debug.go file
 	DD()


### PR DESCRIPTION
- Introduced Exec method in the Query interface to facilitate execution of SQL statements with bindings.
- Enhanced the interface to support direct SQL command execution, improving flexibility in query handling.