### PR TITLE
feat: Implement nil value handling in SQL query compilation

### DIFF
--- a/dbal/query/group.go
+++ b/dbal/query/group.go
@@ -1,6 +1,9 @@
 package query
 
-import "github.com/yaoapp/xun/dbal"
+import (
+	"github.com/yaoapp/xun/dbal"
+	"github.com/yaoapp/xun/utils"
+)
 
 // GroupBy Add a "group by" clause to the query.
 func (builder *Builder) GroupBy(groups ...interface{}) Query {
@@ -27,6 +30,19 @@ func (builder *Builder) Having(column interface{}, args ...interface{}) Query {
 	// passed to the method, we will assume that the operator is an equals sign
 	// and keep going. Otherwise, we'll require the operator to be passed in.
 	operator, value, boolean, offset := builder.prepareWhereArgs(args...)
+
+	if utils.IsNil(value) {
+		havingType := "null"
+		if operator != "=" {
+			havingType = "notnull"
+		}
+		builder.Query.Havings = append(builder.Query.Havings, dbal.Having{
+			Type:    havingType,
+			Column:  column,
+			Boolean: boolean,
+		})
+		return builder
+	}
 
 	builder.Query.Havings = append(builder.Query.Havings, dbal.Having{
 		Type:     typ,
@@ -88,7 +104,7 @@ func (builder *Builder) HavingBetween(column interface{}, values interface{}, ar
 		Offset:  offset,
 	})
 
-	builder.Query.AddBinding("having", havingValues)
+	builder.Query.AddBinding("having", filterNilBindings(havingValues))
 	return builder
 }
 

--- a/dbal/query/query.go
+++ b/dbal/query/query.go
@@ -20,9 +20,10 @@ func (builder *Builder) Table(name string) Query {
 // Get Execute the query as a "select" statement.
 func (builder *Builder) Get(v ...interface{}) ([]xun.R, error) {
 	db := builder.DB()
-	stmt, err := db.Prepare(builder.ToSQL())
+	sql := builder.ToSQL()
+	stmt, err := db.Prepare(sql)
 	if err != nil {
-		defer log.With(log.F{"bindings": builder.GetBindings()}).Error("%s", builder.ToSQL())
+		defer log.With(log.F{"bindings": builder.GetBindings()}).Error("%s", sql)
 		return nil, err
 	}
 

--- a/dbal/query/support.go
+++ b/dbal/query/support.go
@@ -194,6 +194,16 @@ func (builder *Builder) invalidOperator(operator string) bool {
 // 		utils.StringHave([]string{"=", "<>", "!="}, operator)
 // }
 
+func filterNilBindings(values []interface{}) []interface{} {
+	filtered := make([]interface{}, 0, len(values))
+	for _, v := range values {
+		if !utils.IsNil(v) {
+			filtered = append(filtered, v)
+		}
+	}
+	return filtered
+}
+
 // Remove all of the expressions from a list of bindings.
 func (builder *Builder) cleanBindings(bindings interface{}) []interface{} {
 	values := []interface{}{}

--- a/dbal/query/support_test.go
+++ b/dbal/query/support_test.go
@@ -24,3 +24,33 @@ func TestSupportIsBoolean(t *testing.T) {
 	assert.True(t, builder.isBoolean("or"), "The return value should be true")
 	assert.False(t, builder.isBoolean("not"), "The return value should be false")
 }
+
+func TestFilterNilBindingsRemovesNil(t *testing.T) {
+	values := []interface{}{1, nil, "hello", nil, 3}
+	result := filterNilBindings(values)
+	assert.Equal(t, []interface{}{1, "hello", 3}, result)
+}
+
+func TestFilterNilBindingsTypedNil(t *testing.T) {
+	var p *string
+	values := []interface{}{"a", p, "b"}
+	result := filterNilBindings(values)
+	assert.Equal(t, []interface{}{"a", "b"}, result)
+}
+
+func TestFilterNilBindingsAllNil(t *testing.T) {
+	values := []interface{}{nil, nil, nil}
+	result := filterNilBindings(values)
+	assert.Empty(t, result)
+}
+
+func TestFilterNilBindingsNoNil(t *testing.T) {
+	values := []interface{}{1, "two", 3.0}
+	result := filterNilBindings(values)
+	assert.Equal(t, []interface{}{1, "two", 3.0}, result)
+}
+
+func TestFilterNilBindingsEmpty(t *testing.T) {
+	result := filterNilBindings([]interface{}{})
+	assert.Empty(t, result)
+}

--- a/dbal/query/where.go
+++ b/dbal/query/where.go
@@ -432,7 +432,7 @@ func (builder *Builder) whereBetween(column interface{}, values interface{}, boo
 		Offset:  betweenOffset,
 	})
 
-	builder.Query.AddBinding("where", betweenValues)
+	builder.Query.AddBinding("where", filterNilBindings(betweenValues))
 	return builder
 }
 
@@ -486,7 +486,7 @@ func (builder *Builder) whereIn(column interface{}, values interface{}, boolean 
 	// Finally we'll add a binding for each values unless that value is an expression
 	// in which case we will just skip over it since it will be the query as a raw
 	// string and not as a parameterized place-holder to be replaced by the PDO.
-	builder.Query.AddBinding("where", builder.cleanBindings(values))
+	builder.Query.AddBinding("where", filterNilBindings(builder.cleanBindings(values)))
 
 	return builder
 }

--- a/grammar/mysql/compile_test.go
+++ b/grammar/mysql/compile_test.go
@@ -1,0 +1,90 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yaoapp/xun/dbal"
+	goSQL "github.com/yaoapp/xun/grammar/sql"
+)
+
+func newTestMySQL() MySQL {
+	return MySQL{
+		SQL: goSQL.NewSQL(&goSQL.Quoter{}),
+	}
+}
+
+func newMySQLQuery(tableName string) *dbal.Query {
+	return &dbal.Query{
+		From:  dbal.From{Name: dbal.NewName(tableName)},
+		Limit: -1,
+		Bindings: map[string][]interface{}{
+			"select": {}, "from": {}, "join": {},
+			"where": {}, "groupBy": {}, "having": {}, "order": {},
+		},
+	}
+}
+
+func TestCompileUpsertMapWithNilMySQL(t *testing.T) {
+	g := newTestMySQL()
+	q := newMySQLQuery("users")
+	columns := []interface{}{"name", "deleted_at"}
+	values := [][]interface{}{{"alice", nil}}
+	uniqueBy := []interface{}{"name"}
+	updateValues := map[string]interface{}{"deleted_at": nil}
+
+	sql, bindings := g.CompileUpsert(q, columns, values, uniqueBy, updateValues)
+	assert.Contains(t, sql, "on duplicate key update")
+	assert.Contains(t, sql, "NULL")
+	assert.Len(t, bindings, 1, "nil excluded from bindings")
+}
+
+func TestCompileUpsertMapWithTypedNilMySQL(t *testing.T) {
+	g := newTestMySQL()
+	q := newMySQLQuery("users")
+	var p *string
+	columns := []interface{}{"name", "deleted_at"}
+	values := [][]interface{}{{"bob", p}}
+	uniqueBy := []interface{}{"name"}
+	updateValues := map[string]interface{}{"deleted_at": p}
+
+	sql, bindings := g.CompileUpsert(q, columns, values, uniqueBy, updateValues)
+	assert.Contains(t, sql, "on duplicate key update")
+	assert.Contains(t, sql, "NULL")
+	assert.Len(t, bindings, 1, "typed nil excluded from bindings")
+}
+
+func TestCompileUpsertMapNormalValueMySQL(t *testing.T) {
+	g := newTestMySQL()
+	q := newMySQLQuery("users")
+	columns := []interface{}{"name", "email"}
+	values := [][]interface{}{{"alice", "alice@test.com"}}
+	uniqueBy := []interface{}{"email"}
+	updateValues := map[string]interface{}{"name": "alice_updated"}
+
+	sql, bindings := g.CompileUpsert(q, columns, values, uniqueBy, updateValues)
+	assert.Contains(t, sql, "on duplicate key update")
+	assert.Len(t, bindings, 3)
+}
+
+func TestCompileUpsertSliceMySQL(t *testing.T) {
+	g := newTestMySQL()
+	q := newMySQLQuery("users")
+	columns := []interface{}{"name", "email"}
+	values := [][]interface{}{{"alice", "alice@test.com"}}
+	uniqueBy := []interface{}{"email"}
+	updateValues := []string{"name"}
+
+	sql, bindings := g.CompileUpsert(q, columns, values, uniqueBy, updateValues)
+	assert.Contains(t, sql, "on duplicate key update")
+	assert.Contains(t, sql, "values(`name`)")
+	assert.Len(t, bindings, 2)
+}
+
+func TestCompileUpsertEmptyMySQL(t *testing.T) {
+	g := newTestMySQL()
+	q := newMySQLQuery("users")
+	sql, bindings := g.CompileUpsert(q, nil, [][]interface{}{}, nil, nil)
+	assert.Contains(t, sql, "default values")
+	assert.Empty(t, bindings)
+}

--- a/grammar/mysql/update.go
+++ b/grammar/mysql/update.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/yaoapp/xun/dbal"
+	"github.com/yaoapp/xun/utils"
 )
 
 // CompileUpsert Upsert new records or update the existing ones.
@@ -32,7 +33,7 @@ func (grammarSQL MySQL) CompileUpsert(query *dbal.Query, columns []interface{}, 
 			column := fmt.Sprintf("%v", key)
 			value := update.MapIndex(key).Interface()
 			segments = append(segments, fmt.Sprintf("%s=%s", grammarSQL.Wrap(column), grammarSQL.Parameter(value, offset)))
-			if !dbal.IsExpression(value) {
+			if !dbal.IsExpression(value) && !utils.IsNil(value) {
 				bindings = append(bindings, value)
 				offset++
 			}

--- a/grammar/postgres/compile_test.go
+++ b/grammar/postgres/compile_test.go
@@ -804,13 +804,25 @@ func TestVALDefault(t *testing.T) {
 func TestVALEscapeQuotes(t *testing.T) {
 	q := &Quoter{}
 	result := q.VAL("it's")
-	assert.Equal(t, `'it\'s'`, result)
+	assert.Equal(t, `'it''s'`, result)
 }
 
 func TestVALStripNewlines(t *testing.T) {
 	q := &Quoter{}
 	result := q.VAL("line1\nline2\r")
 	assert.Equal(t, "'line1line2'", result)
+}
+
+func TestVALDollarSign(t *testing.T) {
+	q := &Quoter{}
+	result := q.VAL("price is $999 - $4999 /month")
+	assert.Equal(t, "'price is $999 - $4999 /month'", result)
+}
+
+func TestVALQuoteAndDollar(t *testing.T) {
+	q := &Quoter{}
+	result := q.VAL("Custom label (e.g., '$999 - $4999 /month')")
+	assert.Equal(t, "'Custom label (e.g., ''$999 - $4999 /month'')'", result)
 }
 
 // --- Quoter.Wrap ---
@@ -1014,6 +1026,190 @@ func TestIDStripsNewlines(t *testing.T) {
 	q := Quoter{}
 	result := q.ID("us\ners\r")
 	assert.Equal(t, `"users"`, result)
+}
+
+// ---------------------------------------------------------------------------
+// Parameter nil handling (PG quoter)
+// ---------------------------------------------------------------------------
+
+func TestParameterPlainNilPG(t *testing.T) {
+	q := &Quoter{}
+	result := q.Parameter(nil, 1)
+	assert.Equal(t, "NULL", result)
+}
+
+func TestParameterTypedNilPG(t *testing.T) {
+	q := &Quoter{}
+	var p *string
+	result := q.Parameter(p, 1)
+	assert.Equal(t, "NULL", result)
+}
+
+func TestParameterNonNilPG(t *testing.T) {
+	q := &Quoter{}
+	result := q.Parameter("hello", 3)
+	assert.Equal(t, "$3", result)
+}
+
+// ---------------------------------------------------------------------------
+// Parameterize nil handling (PG quoter)
+// ---------------------------------------------------------------------------
+
+func TestParameterizeWithNilPG(t *testing.T) {
+	q := &Quoter{}
+	values := []interface{}{"a", nil, "b"}
+	result := q.Parameterize(values, 0)
+	assert.Equal(t, "$1,NULL,$2", result)
+}
+
+func TestParameterizeWithTypedNilPG(t *testing.T) {
+	q := &Quoter{}
+	var p *string
+	values := []interface{}{"a", p, "b"}
+	result := q.Parameterize(values, 0)
+	assert.Equal(t, "$1,NULL,$2", result)
+}
+
+// ---------------------------------------------------------------------------
+// WhereIn offset with nil (PG)
+// ---------------------------------------------------------------------------
+
+func TestWhereInOffsetWithNilPG(t *testing.T) {
+	pg := newTestPostgres()
+	offset := 0
+	where := dbal.Where{
+		Type:     "in",
+		Column:   "id",
+		ValuesIn: []interface{}{1, nil, 3},
+		Boolean:  "and",
+		Not:      false,
+		Offset:   0,
+	}
+	result := pg.WhereIn(&dbal.Query{}, where, &offset)
+	assert.Contains(t, result, "$1")
+	assert.Contains(t, result, "NULL")
+	assert.Contains(t, result, "$2")
+	assert.Equal(t, 2, offset, "nil should not count in offset")
+}
+
+// ---------------------------------------------------------------------------
+// WhereBetween offset with nil (PG)
+// ---------------------------------------------------------------------------
+
+func TestWhereBetweenMinNilPG(t *testing.T) {
+	pg := newTestPostgres()
+	offset := 0
+	where := dbal.Where{
+		Type:    "between",
+		Column:  "age",
+		Values:  []interface{}{nil, 100},
+		Boolean: "and",
+		Not:     false,
+		Offset:  1,
+	}
+	result := pg.WhereBetween(&dbal.Query{}, where, &offset)
+	assert.Contains(t, result, "NULL")
+	assert.Contains(t, result, "$1")
+	assert.Equal(t, 1, offset)
+}
+
+func TestWhereBetweenBothNilPG(t *testing.T) {
+	pg := newTestPostgres()
+	offset := 0
+	where := dbal.Where{
+		Type:    "between",
+		Column:  "age",
+		Values:  []interface{}{nil, nil},
+		Boolean: "and",
+		Not:     false,
+		Offset:  1,
+	}
+	result := pg.WhereBetween(&dbal.Query{}, where, &offset)
+	assert.Contains(t, result, "NULL and NULL")
+	assert.Equal(t, 0, offset)
+}
+
+func TestWhereBetweenNormalPG(t *testing.T) {
+	pg := newTestPostgres()
+	offset := 0
+	where := dbal.Where{
+		Type:    "between",
+		Column:  "age",
+		Values:  []interface{}{10, 100},
+		Boolean: "and",
+		Not:     false,
+		Offset:  1,
+	}
+	result := pg.WhereBetween(&dbal.Query{}, where, &offset)
+	assert.Contains(t, result, "$1")
+	assert.Contains(t, result, "$2")
+	assert.Equal(t, 2, offset)
+}
+
+// ---------------------------------------------------------------------------
+// CompileUpsert Map with nil (PG)
+// ---------------------------------------------------------------------------
+
+func TestCompileUpsertMapWithTypedNilPG(t *testing.T) {
+	pg := newTestPostgres()
+	q := newFullQuery()
+	var p *string
+	cols := []interface{}{"name", "deleted_at"}
+	vals := [][]interface{}{{"alice", p}}
+	uniqueBy := []interface{}{"name"}
+	updateVals := map[string]interface{}{"deleted_at": p}
+	sql, bindings := pg.CompileUpsert(q, cols, vals, uniqueBy, updateVals)
+	assert.Contains(t, sql, "NULL")
+	assert.Len(t, bindings, 1, "typed nil excluded from bindings")
+}
+
+// ---------------------------------------------------------------------------
+// HavingBetween nil (PG)
+// ---------------------------------------------------------------------------
+
+func TestHavingBetweenMinNilPG(t *testing.T) {
+	pg := newTestPostgres()
+	offset := 0
+	having := dbal.Having{
+		Type:    "between",
+		Column:  "total",
+		Values:  []interface{}{nil, 1000},
+		Boolean: "and",
+		Not:     false,
+		Offset:  1,
+	}
+	result := pg.HavingBetween(&dbal.Query{}, having, &offset)
+	assert.Contains(t, result, "NULL")
+	assert.Contains(t, result, "$1")
+	assert.Equal(t, 1, offset)
+}
+
+// ---------------------------------------------------------------------------
+// CompileHaving null/notnull (PG)
+// ---------------------------------------------------------------------------
+
+func TestCompileHavingNullPG(t *testing.T) {
+	pg := newTestPostgres()
+	offset := 0
+	having := dbal.Having{
+		Type:    "null",
+		Column:  "total",
+		Boolean: "and",
+	}
+	result := pg.CompileHaving(&dbal.Query{}, having, &offset)
+	assert.Equal(t, `and "total" is null`, result)
+}
+
+func TestCompileHavingNotnullPG(t *testing.T) {
+	pg := newTestPostgres()
+	offset := 0
+	having := dbal.Having{
+		Type:    "notnull",
+		Column:  "total",
+		Boolean: "and",
+	}
+	result := pg.CompileHaving(&dbal.Query{}, having, &offset)
+	assert.Equal(t, `and "total" is not null`, result)
 }
 
 func TestGetOperatorsPG(t *testing.T) {

--- a/grammar/postgres/quoter.go
+++ b/grammar/postgres/quoter.go
@@ -38,7 +38,7 @@ func (quoter Quoter) VAL(v interface{}) string {
 	default:
 		input = fmt.Sprintf("%v", v)
 	}
-	input = strings.ReplaceAll(input, "'", "\\'")
+	input = strings.ReplaceAll(input, "'", "''")
 	input = strings.ReplaceAll(input, "\n", "")
 	input = strings.ReplaceAll(input, "\r", "")
 	return "'" + input + "'"
@@ -112,7 +112,7 @@ func (quoter *Quoter) Parameter(value interface{}, num int) string {
 	if quoter.IsExpression(value) {
 		return value.(dbal.Expression).GetValue()
 	}
-	if value == nil {
+	if utils.IsNil(value) {
 		return "NULL"
 	}
 	return fmt.Sprintf("$%d", num)
@@ -123,7 +123,7 @@ func (quoter *Quoter) Parameterize(values []interface{}, offset int) string {
 	params := []string{}
 	bindingNum := offset
 	for _, value := range values {
-		if !quoter.IsExpression(value) && value != nil {
+		if !quoter.IsExpression(value) && !utils.IsNil(value) {
 			bindingNum++
 		}
 		params = append(params, quoter.Parameter(value, bindingNum))

--- a/grammar/postgres/update.go
+++ b/grammar/postgres/update.go
@@ -9,6 +9,7 @@ import (
 	"github.com/yaoapp/kun/log"
 	"github.com/yaoapp/xun"
 	"github.com/yaoapp/xun/dbal"
+	"github.com/yaoapp/xun/utils"
 )
 
 // Upsert Upsert new records or update the existing ones.
@@ -53,7 +54,7 @@ func (grammarSQL Postgres) CompileUpsert(query *dbal.Query, columns []interface{
 			column := fmt.Sprintf("%v", key)
 			value := update.MapIndex(key).Interface()
 			segments = append(segments, fmt.Sprintf("%s=%s", grammarSQL.Wrap(column), grammarSQL.Parameter(value, offset)))
-			if !dbal.IsExpression(value) && value != nil {
+			if !dbal.IsExpression(value) && !utils.IsNil(value) {
 				bindings = append(bindings, value)
 				offset++
 			}

--- a/grammar/sql/compile.go
+++ b/grammar/sql/compile.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yaoapp/xun"
 	"github.com/yaoapp/xun/dbal"
+	"github.com/yaoapp/xun/utils"
 )
 
 // CompileSelect Compile a select query into SQL.
@@ -270,13 +271,17 @@ func (grammarSQL SQL) CompileHaving(query *dbal.Query, having dbal.Having, bindi
 		return fmt.Sprintf("%s %s", having.Boolean, having.SQL)
 	} else if having.Type == "between" {
 		return grammarSQL.HavingBetween(query, having, bindingOffset)
+	} else if having.Type == "null" {
+		return fmt.Sprintf("%s %s is null", having.Boolean, grammarSQL.Wrap(having.Column))
+	} else if having.Type == "notnull" {
+		return fmt.Sprintf("%s %s is not null", having.Boolean, grammarSQL.Wrap(having.Column))
 	}
 	return grammarSQL.HavingBasic(query, having, bindingOffset)
 }
 
 // HavingBasic  Compile a basic having clause.
 func (grammarSQL SQL) HavingBasic(query *dbal.Query, having dbal.Having, bindingOffset *int) string {
-	if !dbal.IsExpression(having.Value) {
+	if !dbal.IsExpression(having.Value) && !utils.IsNil(having.Value) {
 		*bindingOffset = *bindingOffset + having.Offset
 	}
 	column := grammarSQL.Wrap(having.Column)
@@ -295,12 +300,12 @@ func (grammarSQL SQL) HavingBetween(query *dbal.Query, having dbal.Having, bindi
 		between = "not between"
 	}
 	column := grammarSQL.Wrap(having.Column)
-	if !dbal.IsExpression(having.Values[0]) {
+	if !dbal.IsExpression(having.Values[0]) && !utils.IsNil(having.Values[0]) {
 		*bindingOffset = *bindingOffset + having.Offset
 	}
 	min := grammarSQL.Parameter(having.Values[0], *bindingOffset)
 
-	if !dbal.IsExpression(having.Values[1]) {
+	if !dbal.IsExpression(having.Values[1]) && !utils.IsNil(having.Values[1]) {
 		*bindingOffset = *bindingOffset + having.Offset
 	}
 	max := grammarSQL.Parameter(having.Values[1], *bindingOffset)
@@ -505,9 +510,13 @@ func (grammarSQL SQL) WhereBetween(query *dbal.Query, where dbal.Where, bindingO
 		between = "not between"
 	}
 	column := grammarSQL.Wrap(where.Column)
-	*bindingOffset = *bindingOffset + where.Offset
+	if !grammarSQL.IsExpression(where.Values[0]) && !utils.IsNil(where.Values[0]) {
+		*bindingOffset = *bindingOffset + where.Offset
+	}
 	min := grammarSQL.Parameter(where.Values[0], *bindingOffset)
-	*bindingOffset = *bindingOffset + 1
+	if !grammarSQL.IsExpression(where.Values[1]) && !utils.IsNil(where.Values[1]) {
+		*bindingOffset = *bindingOffset + 1
+	}
 	max := grammarSQL.Parameter(where.Values[1], *bindingOffset)
 	// `field` between 3 and 5
 	// `field` not between 3 and 5
@@ -535,7 +544,13 @@ func (grammarSQL SQL) WhereIn(query *dbal.Query, where dbal.Where, bindingOffset
 			}
 
 			sql = fmt.Sprintf("%s %s (%s)", grammarSQL.Wrap(where.Column), in, grammarSQL.Parameterize(values, *bindingOffset))
-			*bindingOffset = *bindingOffset + len(values)
+			count := 0
+			for _, v := range values {
+				if !grammarSQL.IsExpression(v) && !utils.IsNil(v) {
+					count++
+				}
+			}
+			*bindingOffset = *bindingOffset + count
 		} else if _, ok := where.ValuesIn.(dbal.Expression); ok {
 			*bindingOffset = *bindingOffset + where.Offset
 			sql = fmt.Sprintf("%s %s (%s)", grammarSQL.Wrap(where.Column), in, where.ValuesIn.(dbal.Expression).GetValue())

--- a/grammar/sql/compile_test.go
+++ b/grammar/sql/compile_test.go
@@ -5,7 +5,674 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/yaoapp/xun/dbal"
+	"github.com/yaoapp/xun/utils"
 )
+
+// ---------------------------------------------------------------------------
+// Parameter / Parameterize nil handling (sql quoter)
+// ---------------------------------------------------------------------------
+
+func TestParameterPlainNil(t *testing.T) {
+	g := newTestSQL()
+	result := g.Parameter(nil, 1)
+	assert.Equal(t, "NULL", result)
+}
+
+func TestParameterTypedNil(t *testing.T) {
+	g := newTestSQL()
+	var p *string
+	result := g.Parameter(p, 1)
+	assert.Equal(t, "NULL", result)
+}
+
+func TestParameterNonNil(t *testing.T) {
+	g := newTestSQL()
+	result := g.Parameter("hello", 1)
+	assert.Equal(t, "?", result)
+}
+
+// ---------------------------------------------------------------------------
+// CompileInsert nil handling
+// ---------------------------------------------------------------------------
+
+func TestCompileInsertWithNilValue(t *testing.T) {
+	g := newTestSQL()
+	q := &dbal.Query{From: dbal.From{Name: dbal.NewName("users")}}
+	cols := []interface{}{"name", "deleted_at"}
+	vals := [][]interface{}{{"alice", nil}}
+	sql, bindings := g.CompileInsert(q, cols, vals)
+	assert.Contains(t, sql, "NULL")
+	assert.Equal(t, []interface{}{"alice"}, bindings)
+}
+
+func TestCompileInsertWithTypedNil(t *testing.T) {
+	g := newTestSQL()
+	q := &dbal.Query{From: dbal.From{Name: dbal.NewName("users")}}
+	var p *string
+	cols := []interface{}{"name", "deleted_at"}
+	vals := [][]interface{}{{"bob", p}}
+	sql, bindings := g.CompileInsert(q, cols, vals)
+	assert.Contains(t, sql, "NULL")
+	assert.Equal(t, []interface{}{"bob"}, bindings)
+}
+
+// ---------------------------------------------------------------------------
+// CompileUpdateColumns nil handling
+// ---------------------------------------------------------------------------
+
+func TestCompileUpdateColumnsWithNil(t *testing.T) {
+	g := newTestSQL()
+	q := &dbal.Query{From: dbal.From{Name: dbal.NewName("users")}}
+	offset := 0
+	cols, bindings := g.CompileUpdateColumns(q, map[string]interface{}{"deleted_at": nil}, &offset)
+	assert.Contains(t, cols, "NULL")
+	assert.Empty(t, bindings)
+	assert.Equal(t, 0, offset)
+}
+
+func TestCompileUpdateColumnsWithTypedNil(t *testing.T) {
+	g := newTestSQL()
+	q := &dbal.Query{From: dbal.From{Name: dbal.NewName("users")}}
+	var p *string
+	offset := 0
+	cols, bindings := g.CompileUpdateColumns(q, map[string]interface{}{"deleted_at": p}, &offset)
+	assert.Contains(t, cols, "NULL")
+	assert.Empty(t, bindings)
+	assert.Equal(t, 0, offset)
+}
+
+// ---------------------------------------------------------------------------
+// WhereIn offset with nil
+// ---------------------------------------------------------------------------
+
+func TestWhereInOffsetWithNil(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	where := dbal.Where{
+		Type:     "in",
+		Column:   "id",
+		ValuesIn: []interface{}{1, nil, 3},
+		Boolean:  "and",
+		Not:      false,
+		Offset:   0,
+	}
+	result := g.WhereIn(&dbal.Query{}, where, &offset)
+	assert.Contains(t, result, "in")
+	assert.Equal(t, 2, offset, "nil should not count in offset")
+}
+
+func TestWhereInOffsetAllNil(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	where := dbal.Where{
+		Type:     "in",
+		Column:   "id",
+		ValuesIn: []interface{}{nil, nil},
+		Boolean:  "and",
+		Not:      false,
+		Offset:   0,
+	}
+	g.WhereIn(&dbal.Query{}, where, &offset)
+	assert.Equal(t, 0, offset, "all nil -> offset stays 0")
+}
+
+func TestWhereInOffsetNoNil(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	where := dbal.Where{
+		Type:     "in",
+		Column:   "id",
+		ValuesIn: []interface{}{1, 2, 3},
+		Boolean:  "and",
+		Not:      false,
+		Offset:   0,
+	}
+	g.WhereIn(&dbal.Query{}, where, &offset)
+	assert.Equal(t, 3, offset, "no nil -> offset = len(values)")
+}
+
+// ---------------------------------------------------------------------------
+// WhereBetween offset with nil
+// ---------------------------------------------------------------------------
+
+func TestWhereBetweenOffsetMinNil(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	where := dbal.Where{
+		Type:    "between",
+		Column:  "age",
+		Values:  []interface{}{nil, 100},
+		Boolean: "and",
+		Not:     false,
+		Offset:  1,
+	}
+	result := g.WhereBetween(&dbal.Query{}, where, &offset)
+	assert.Contains(t, result, "between")
+	assert.Contains(t, result, "NULL")
+	assert.Equal(t, 1, offset, "only max counts")
+}
+
+func TestWhereBetweenOffsetMaxNil(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	where := dbal.Where{
+		Type:    "between",
+		Column:  "age",
+		Values:  []interface{}{10, nil},
+		Boolean: "and",
+		Not:     false,
+		Offset:  1,
+	}
+	result := g.WhereBetween(&dbal.Query{}, where, &offset)
+	assert.Contains(t, result, "between")
+	assert.Contains(t, result, "NULL")
+	assert.Equal(t, 1, offset, "only min counts")
+}
+
+func TestWhereBetweenOffsetBothNil(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	where := dbal.Where{
+		Type:    "between",
+		Column:  "age",
+		Values:  []interface{}{nil, nil},
+		Boolean: "and",
+		Not:     false,
+		Offset:  1,
+	}
+	g.WhereBetween(&dbal.Query{}, where, &offset)
+	assert.Equal(t, 0, offset, "both nil -> offset unchanged")
+}
+
+func TestWhereBetweenOffsetNormal(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	where := dbal.Where{
+		Type:    "between",
+		Column:  "age",
+		Values:  []interface{}{10, 100},
+		Boolean: "and",
+		Not:     false,
+		Offset:  1,
+	}
+	g.WhereBetween(&dbal.Query{}, where, &offset)
+	assert.Equal(t, 2, offset, "normal -> offset = 2")
+}
+
+// ---------------------------------------------------------------------------
+// HavingBetween offset with nil
+// ---------------------------------------------------------------------------
+
+func TestHavingBetweenOffsetMinNil(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	having := dbal.Having{
+		Type:    "between",
+		Column:  "total",
+		Values:  []interface{}{nil, 1000},
+		Boolean: "and",
+		Not:     false,
+		Offset:  1,
+	}
+	result := g.HavingBetween(&dbal.Query{}, having, &offset)
+	assert.Contains(t, result, "between")
+	assert.Contains(t, result, "NULL")
+	assert.Equal(t, 1, offset)
+}
+
+func TestHavingBetweenOffsetBothNil(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	having := dbal.Having{
+		Type:    "between",
+		Column:  "total",
+		Values:  []interface{}{nil, nil},
+		Boolean: "and",
+		Not:     false,
+		Offset:  1,
+	}
+	g.HavingBetween(&dbal.Query{}, having, &offset)
+	assert.Equal(t, 0, offset)
+}
+
+func TestHavingBetweenOffsetNormal(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	having := dbal.Having{
+		Type:    "between",
+		Column:  "total",
+		Values:  []interface{}{100, 1000},
+		Boolean: "and",
+		Not:     false,
+		Offset:  1,
+	}
+	g.HavingBetween(&dbal.Query{}, having, &offset)
+	assert.Equal(t, 2, offset)
+}
+
+// ---------------------------------------------------------------------------
+// HavingBasic offset with nil
+// ---------------------------------------------------------------------------
+
+func TestHavingBasicOffsetNil(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	having := dbal.Having{
+		Type:     "basic",
+		Column:   "total",
+		Operator: "=",
+		Value:    nil,
+		Boolean:  "and",
+		Offset:   1,
+	}
+	result := g.HavingBasic(&dbal.Query{}, having, &offset)
+	assert.Contains(t, result, "NULL")
+	assert.Equal(t, 0, offset, "nil value -> no offset increment")
+}
+
+func TestHavingBasicOffsetTypedNil(t *testing.T) {
+	g := newTestSQL()
+	var p *int
+	offset := 0
+	having := dbal.Having{
+		Type:     "basic",
+		Column:   "total",
+		Operator: "=",
+		Value:    p,
+		Boolean:  "and",
+		Offset:   1,
+	}
+	result := g.HavingBasic(&dbal.Query{}, having, &offset)
+	assert.Contains(t, result, "NULL")
+	assert.Equal(t, 0, offset)
+}
+
+func TestHavingBasicOffsetNormal(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	having := dbal.Having{
+		Type:     "basic",
+		Column:   "total",
+		Operator: ">",
+		Value:    100,
+		Boolean:  "and",
+		Offset:   1,
+	}
+	g.HavingBasic(&dbal.Query{}, having, &offset)
+	assert.Equal(t, 1, offset)
+}
+
+// ---------------------------------------------------------------------------
+// CompileHaving null / notnull types
+// ---------------------------------------------------------------------------
+
+func TestCompileHavingNull(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	having := dbal.Having{
+		Type:    "null",
+		Column:  "total",
+		Boolean: "and",
+	}
+	result := g.CompileHaving(&dbal.Query{}, having, &offset)
+	assert.Equal(t, "and `total` is null", result)
+	assert.Equal(t, 0, offset)
+}
+
+func TestCompileHavingNotnull(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	having := dbal.Having{
+		Type:    "notnull",
+		Column:  "total",
+		Boolean: "and",
+	}
+	result := g.CompileHaving(&dbal.Query{}, having, &offset)
+	assert.Equal(t, "and `total` is not null", result)
+	assert.Equal(t, 0, offset)
+}
+
+// ---------------------------------------------------------------------------
+// utils.IsNil coverage for typed nil in parameter
+// ---------------------------------------------------------------------------
+
+func TestIsNilPlainNil(t *testing.T) {
+	assert.True(t, utils.IsNil(nil))
+}
+
+func TestIsNilTypedNilPtr(t *testing.T) {
+	var p *string
+	assert.True(t, utils.IsNil(p))
+}
+
+func TestIsNilNonNilValue(t *testing.T) {
+	s := "hello"
+	assert.False(t, utils.IsNil(&s))
+}
+
+func TestIsNilNonPointer(t *testing.T) {
+	assert.False(t, utils.IsNil(42))
+}
+
+// ---------------------------------------------------------------------------
+// CompileHaving raw type
+// ---------------------------------------------------------------------------
+
+func TestCompileHavingRaw(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	having := dbal.Having{
+		Type:    "raw",
+		SQL:     "count(*) > 5",
+		Boolean: "and",
+	}
+	result := g.CompileHaving(&dbal.Query{}, having, &offset)
+	assert.Equal(t, "and count(*) > 5", result)
+	assert.Equal(t, 0, offset)
+}
+
+// ---------------------------------------------------------------------------
+// CompileHaving default branch (basic)
+// ---------------------------------------------------------------------------
+
+func TestCompileHavingBasicViaCompileHaving(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	having := dbal.Having{
+		Type:     "basic",
+		Column:   "total",
+		Operator: ">",
+		Value:    100,
+		Boolean:  "and",
+		Offset:   1,
+	}
+	result := g.CompileHaving(&dbal.Query{}, having, &offset)
+	assert.Contains(t, result, ">")
+	assert.Equal(t, 1, offset)
+}
+
+// ---------------------------------------------------------------------------
+// HavingBetween: Not=true branch
+// ---------------------------------------------------------------------------
+
+func TestHavingBetweenNotBetween(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	having := dbal.Having{
+		Type:    "between",
+		Column:  "total",
+		Values:  []interface{}{10, 1000},
+		Boolean: "and",
+		Not:     true,
+		Offset:  1,
+	}
+	result := g.HavingBetween(&dbal.Query{}, having, &offset)
+	assert.Contains(t, result, "not between")
+	assert.Equal(t, 2, offset)
+}
+
+// ---------------------------------------------------------------------------
+// HavingBetween: Expression values
+// ---------------------------------------------------------------------------
+
+func TestHavingBetweenWithExpression(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	having := dbal.Having{
+		Type:    "between",
+		Column:  "total",
+		Values:  []interface{}{dbal.Raw("NOW()"), 1000},
+		Boolean: "and",
+		Not:     false,
+		Offset:  1,
+	}
+	result := g.HavingBetween(&dbal.Query{}, having, &offset)
+	assert.Contains(t, result, "NOW()")
+	assert.Equal(t, 1, offset, "expression min skips offset, only max counts")
+}
+
+// ---------------------------------------------------------------------------
+// WhereBetween: Not=true branch
+// ---------------------------------------------------------------------------
+
+func TestWhereBetweenNotBetween(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	where := dbal.Where{
+		Type:    "between",
+		Column:  "age",
+		Values:  []interface{}{10, 100},
+		Boolean: "and",
+		Not:     true,
+		Offset:  1,
+	}
+	result := g.WhereBetween(&dbal.Query{}, where, &offset)
+	assert.Contains(t, result, "not between")
+	assert.Equal(t, 2, offset)
+}
+
+// ---------------------------------------------------------------------------
+// WhereBetween: Expression value
+// ---------------------------------------------------------------------------
+
+func TestWhereBetweenWithExpression(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	where := dbal.Where{
+		Type:    "between",
+		Column:  "age",
+		Values:  []interface{}{dbal.Raw("MIN(age)"), 100},
+		Boolean: "and",
+		Not:     false,
+		Offset:  1,
+	}
+	result := g.WhereBetween(&dbal.Query{}, where, &offset)
+	assert.Contains(t, result, "MIN(age)")
+	assert.Equal(t, 1, offset, "expression min skips, only max counted")
+}
+
+// ---------------------------------------------------------------------------
+// WhereIn: Not=true, nil ValuesIn, Expression subquery
+// ---------------------------------------------------------------------------
+
+func TestWhereInNotIn(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	where := dbal.Where{
+		Type:     "in",
+		Column:   "id",
+		ValuesIn: []interface{}{1, 2, 3},
+		Boolean:  "and",
+		Not:      true,
+		Offset:   0,
+	}
+	result := g.WhereIn(&dbal.Query{}, where, &offset)
+	assert.Contains(t, result, "not in")
+	assert.Equal(t, 3, offset)
+}
+
+func TestWhereInNilValues(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	where := dbal.Where{
+		Type:     "in",
+		Column:   "id",
+		ValuesIn: nil,
+		Boolean:  "and",
+		Not:      false,
+		Offset:   0,
+	}
+	result := g.WhereIn(&dbal.Query{}, where, &offset)
+	assert.Equal(t, "false = true", result)
+}
+
+func TestWhereInNilValuesNot(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	where := dbal.Where{
+		Type:     "in",
+		Column:   "id",
+		ValuesIn: nil,
+		Boolean:  "and",
+		Not:      true,
+		Offset:   0,
+	}
+	result := g.WhereIn(&dbal.Query{}, where, &offset)
+	assert.Equal(t, "true = true", result)
+}
+
+func TestWhereInExpressionSubquery(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	where := dbal.Where{
+		Type:     "in",
+		Column:   "id",
+		ValuesIn: dbal.Raw("SELECT id FROM users"),
+		Boolean:  "and",
+		Not:      false,
+		Offset:   0,
+	}
+	result := g.WhereIn(&dbal.Query{}, where, &offset)
+	assert.Contains(t, result, "SELECT id FROM users")
+}
+
+func TestWhereInWithExpressionValues(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	where := dbal.Where{
+		Type:     "in",
+		Column:   "id",
+		ValuesIn: []interface{}{1, dbal.Raw("NOW()"), 3},
+		Boolean:  "and",
+		Not:      false,
+		Offset:   0,
+	}
+	result := g.WhereIn(&dbal.Query{}, where, &offset)
+	assert.Contains(t, result, "NOW()")
+	assert.Equal(t, 2, offset, "expression skipped in count")
+}
+
+// ---------------------------------------------------------------------------
+// Parameter: Expression branch
+// ---------------------------------------------------------------------------
+
+func TestParameterExpression(t *testing.T) {
+	g := newTestSQL()
+	result := g.Parameter(dbal.Raw("NOW()"), 1)
+	assert.Equal(t, "NOW()", result)
+}
+
+// ---------------------------------------------------------------------------
+// CompileUpdateColumns: Expression value branch
+// ---------------------------------------------------------------------------
+
+func TestCompileUpdateColumnsWithExpression(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	query := &dbal.Query{}
+	values := map[string]interface{}{
+		"updated_at": dbal.Raw("NOW()"),
+		"name":       "alice",
+	}
+	sql, bindings := g.CompileUpdateColumns(query, values, &offset)
+	assert.Contains(t, sql, "NOW()")
+	assert.Contains(t, sql, "?")
+	assert.Equal(t, 1, len(bindings), "expression excluded from bindings")
+}
+
+// ---------------------------------------------------------------------------
+// CompileHaving via CompileHaving: between branch
+// ---------------------------------------------------------------------------
+
+func TestCompileHavingBetweenBranch(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	having := dbal.Having{
+		Type:    "between",
+		Column:  "total",
+		Values:  []interface{}{10, 1000},
+		Boolean: "and",
+		Not:     false,
+		Offset:  1,
+	}
+	result := g.CompileHaving(&dbal.Query{}, having, &offset)
+	assert.Contains(t, result, "between")
+	assert.Equal(t, 2, offset)
+}
+
+// ---------------------------------------------------------------------------
+// HavingBetween: panic on invalid values length
+// ---------------------------------------------------------------------------
+
+func TestHavingBetweenPanicsOnBadLength(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	having := dbal.Having{
+		Type:    "between",
+		Column:  "total",
+		Values:  []interface{}{10},
+		Boolean: "and",
+		Offset:  1,
+	}
+	assert.Panics(t, func() {
+		g.HavingBetween(&dbal.Query{}, having, &offset)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// WhereBetween: panic on invalid values length
+// ---------------------------------------------------------------------------
+
+func TestWhereBetweenPanicsOnBadLength(t *testing.T) {
+	g := newTestSQL()
+	offset := 0
+	where := dbal.Where{
+		Type:    "between",
+		Column:  "age",
+		Values:  []interface{}{10},
+		Boolean: "and",
+		Offset:  1,
+	}
+	assert.Panics(t, func() {
+		g.WhereBetween(&dbal.Query{}, where, &offset)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CompileInsert: Expression, nil, empty values
+// ---------------------------------------------------------------------------
+
+func TestCompileInsertWithExpression(t *testing.T) {
+	g := newTestSQL()
+	query := newBaseQuery("users")
+	columns := []interface{}{"name", "created_at"}
+	values := [][]interface{}{{"alice", dbal.Raw("NOW()")}}
+	sql, bindings := g.CompileInsert(query, columns, values)
+	assert.Contains(t, sql, "NOW()")
+	assert.Equal(t, 1, len(bindings))
+	assert.Equal(t, "alice", bindings[0])
+	_ = sql
+}
+
+func TestCompileInsertDefaultValues(t *testing.T) {
+	g := newTestSQL()
+	query := newBaseQuery("users")
+	sql, bindings := g.CompileInsert(query, []interface{}{}, [][]interface{}{})
+	assert.Contains(t, sql, "default values")
+	assert.Nil(t, bindings)
+}
+
+func newBaseQuery(tableName string) *dbal.Query {
+	return &dbal.Query{
+		From:   dbal.From{Type: "table", Name: dbal.NewName(tableName)},
+		Limit:  -1,
+		Offset: -1,
+		Bindings: map[string][]interface{}{
+			"select": {}, "from": {}, "join": {},
+			"where": {}, "groupBy": {}, "having": {}, "order": {},
+		},
+	}
+}
 
 func newTestSQL() SQL {
 	return NewSQL(&Quoter{})

--- a/grammar/sql/insert.go
+++ b/grammar/sql/insert.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/yaoapp/xun/dbal"
+	"github.com/yaoapp/xun/utils"
 )
 
 // CompileInsert Compile an insert statement into SQL.
@@ -21,7 +22,7 @@ func (grammarSQL SQL) CompileInsert(query *dbal.Query, columns []interface{}, va
 	for _, value := range values {
 		parameters = append(parameters, fmt.Sprintf("(%s)", grammarSQL.Parameterize(value, offset)))
 		for _, v := range value {
-			if !dbal.IsExpression(v) && v != nil {
+			if !dbal.IsExpression(v) && !utils.IsNil(v) {
 				bindings = append(bindings, v)
 				offset++
 			}

--- a/grammar/sql/quoter.go
+++ b/grammar/sql/quoter.go
@@ -154,7 +154,7 @@ func (quoter *Quoter) Parameter(value interface{}, num int) string {
 	if quoter.IsExpression(value) {
 		return value.(dbal.Expression).GetValue()
 	}
-	if value == nil {
+	if utils.IsNil(value) {
 		return "NULL"
 	}
 	return "?"

--- a/grammar/sql/update.go
+++ b/grammar/sql/update.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/yaoapp/xun/dbal"
+	"github.com/yaoapp/xun/utils"
 )
 
 // CompileUpsert Compile an "upsert" statement into SQL.
@@ -41,7 +42,7 @@ func (grammarSQL SQL) CompileUpdateColumns(query *dbal.Query, values map[string]
 	bindings := []interface{}{}
 	for key, value := range values {
 		columns = append(columns, fmt.Sprintf("%s=%s", grammarSQL.Wrap(key), grammarSQL.Parameter(value, *offset+1)))
-		if !dbal.IsExpression(value) && value != nil {
+		if !dbal.IsExpression(value) && !utils.IsNil(value) {
 			bindings = append(bindings, value)
 			*offset++
 		}

--- a/grammar/sqlite3/compile_test.go
+++ b/grammar/sqlite3/compile_test.go
@@ -737,6 +737,38 @@ func TestCompileSelectColumnsResetAfterCompile(t *testing.T) {
 	assert.Equal(t, originalColumns, query.Columns)
 }
 
+// ---------------------------------------------------------------------------
+// CompileUpsert Map with nil (SQLite3)
+// ---------------------------------------------------------------------------
+
+func TestCompileUpsertMapWithNilSQLite(t *testing.T) {
+	g := newTestSQLite3()
+	query := newBaseQuery("users")
+	columns := []interface{}{"name", "deleted_at"}
+	values := [][]interface{}{{"alice", nil}}
+	uniqueBy := []interface{}{"name"}
+	updateValues := map[string]interface{}{"deleted_at": nil}
+
+	sql, bindings := g.CompileUpsert(query, columns, values, uniqueBy, updateValues)
+	assert.Contains(t, sql, "NULL")
+	assert.Contains(t, sql, "on conflict")
+	assert.Len(t, bindings, 1, "nil excluded from bindings in both insert and upsert map")
+}
+
+func TestCompileUpsertMapWithTypedNilSQLite(t *testing.T) {
+	g := newTestSQLite3()
+	query := newBaseQuery("users")
+	var p *string
+	columns := []interface{}{"name", "deleted_at"}
+	values := [][]interface{}{{"bob", p}}
+	uniqueBy := []interface{}{"name"}
+	updateValues := map[string]interface{}{"deleted_at": p}
+
+	sql, bindings := g.CompileUpsert(query, columns, values, uniqueBy, updateValues)
+	assert.Contains(t, sql, "NULL")
+	assert.Len(t, bindings, 1, "typed nil excluded from bindings")
+}
+
 func TestGetOperatorsSQLite(t *testing.T) {
 	g := newTestSQLite3()
 	ops := g.GetOperators()

--- a/grammar/sqlite3/update.go
+++ b/grammar/sqlite3/update.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/yaoapp/xun/dbal"
+	"github.com/yaoapp/xun/utils"
 )
 
 // CompileUpsert Upsert new records or update the existing ones.
@@ -32,7 +33,7 @@ func (grammarSQL SQLite3) CompileUpsert(query *dbal.Query, columns []interface{}
 			column := fmt.Sprintf("%v", key)
 			value := update.MapIndex(key).Interface()
 			segments = append(segments, fmt.Sprintf("%s=%s", grammarSQL.Wrap(column), grammarSQL.Parameter(value, offset)))
-			if !dbal.IsExpression(value) {
+			if !dbal.IsExpression(value) && !utils.IsNil(value) {
 				bindings = append(bindings, value)
 				offset++
 			}


### PR DESCRIPTION
- Added a new utility function `filterNilBindings` to filter out nil values from query bindings, ensuring that SQL queries are constructed correctly without including nil parameters.
- Updated various query compilation methods across MySQL, PostgreSQL, and SQLite3 grammars to utilize the new nil handling logic, improving the robustness of query execution.
- Enhanced unit tests to cover scenarios involving nil values in query parameters, ensuring comprehensive validation of the new functionality.